### PR TITLE
Remove init from public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,7 @@ deno run --allow-net --allow-write --allow-read --allow-plugin --unstable xxx.ts
 ## Examples
 
 ```ts
-import { init, MongoClient } from "https://deno.land/x/mongo@v0.6.0/mod.ts";
-
-// Initialize the plugin
-await init();
+import { MongoClient } from "https://deno.land/x/mongo@v0.6.0/mod.ts";
 
 const client = new MongoClient();
 client.connectWithUri("mongodb://localhost:27017");

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,5 @@
+import { init } from "./ts/util.ts";
+
 export * from "./ts/client.ts";
 export * from "./ts/collection.ts";
 export * from "./ts/database.ts";
@@ -7,3 +9,5 @@ export * from "./ts/util.ts";
 export const VERSION = "v0.6.0";
 export const RELEASE_URL =
   `https://github.com/manyuanrong/deno_mongo/releases/download/${VERSION}`;
+
+await init();

--- a/mod.ts
+++ b/mod.ts
@@ -10,4 +10,4 @@ export const VERSION = "v0.6.0";
 export const RELEASE_URL =
   `https://github.com/manyuanrong/deno_mongo/releases/download/${VERSION}`;
 
-await init();
+await init(RELEASE_URL);

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,6 @@
 import { cargoBuild } from "./build.ts";
-import { init, MongoClient } from "./mod.ts";
+import { init } from "./ts/util.ts";
+import { MongoClient } from "./ts/client.ts";
 import { assert, assertEquals, exists } from "./test.deps.ts";
 import { ObjectId } from "./ts/types.ts";
 

--- a/ts/util.ts
+++ b/ts/util.ts
@@ -1,5 +1,4 @@
 import { prepare } from "../deps.ts";
-import { RELEASE_URL } from "../mod.ts";
 import { CommandType } from "./types.ts";
 
 // @ts-ignore
@@ -29,7 +28,7 @@ interface Command {
   command_id?: number;
 }
 
-export async function init(releaseUrl = RELEASE_URL) {
+export async function init(releaseUrl: string) {
   const options = {
     name: PLUGIN_NAME,
     urls: {


### PR DESCRIPTION
Internally call `await init()` when the module is loaded.

As suggested in #24.