### PR TITLE
Fix ObjectId regex and add tests for invalid ids

### DIFF
--- a/ts/tests/types-check.test.ts
+++ b/ts/tests/types-check.test.ts
@@ -6,7 +6,7 @@ const { test } = Deno;
 test("ObjectId parse", () => {
   let $oid = "d3e48b03-7baf-4d98-8df7-5002a8fae5e4";
   assertThrows(() => ObjectId($oid));
-  
+
   $oid = "5e63a91b00d839ae0084dfe4";
   assertEquals(ObjectId($oid), { $oid });
 

--- a/ts/tests/types-check.test.ts
+++ b/ts/tests/types-check.test.ts
@@ -6,6 +6,13 @@ const { test } = Deno;
 test("ObjectId parse", () => {
   let $oid = "d3e48b03-7baf-4d98-8df7-5002a8fae5e4";
   assertThrows(() => ObjectId($oid));
+  
   $oid = "5e63a91b00d839ae0084dfe4";
   assertEquals(ObjectId($oid), { $oid });
+
+  $oid = "INVALID-5e63a91b00d839ae0084dfe4";
+  assertThrows(() => ObjectId($oid));
+
+  $oid = "5e63a91b00d839ae0084dfe4-INVALID";
+  assertThrows(() => ObjectId($oid));
 });

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -17,7 +17,7 @@ export interface ObjectId {
   $oid: string;
 }
 export function ObjectId($oid: string) {
-  const isLegal = /[0-9a-fA-F]{24}/.test($oid);
+  const isLegal = /^[0-9a-fA-F]{24}$/.test($oid);
   if (!isLegal) {
     throw new Error(`ObjectId("${$oid}") is not legal.`);
   }


### PR DESCRIPTION
Update the regex used for id validation, so that it matches the **whole** string.
Add two more tests for invalid ids.

Fixes #28.