### PR TITLE
fix collection class generic

### DIFF
--- a/ts/collection.ts
+++ b/ts/collection.ts
@@ -4,7 +4,7 @@ import { CommandType, FindOptions } from "./types.ts";
 import { convert, parse } from "./type_convert.ts";
 import { dispatchAsync, encode } from "./util.ts";
 
-export class Collection<T = any> {
+export class Collection<T> {
   constructor(
     private readonly client: MongoClient,
     private readonly dbName: string,


### PR DESCRIPTION
In the collection class we cannot define and generic type in our API using mongo if we have export class Collection<T=any>
for example:
```sh
const users = db.collection<UserSchema>("users");
```
we will be possible