### PR TITLE
Added support for skip() and limit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,10 @@ const deleteCount = await users.deleteOne({ _id: insertId });
 
 // deleteMany
 const deleteCount2 = await users.deleteMany({ username: "test" });
+
+// Skip
+const skipTwo = await users.skip(2).find();
+
+// Limit
+const featuredUser = await users.limit(5).find();
 ```

--- a/README.md
+++ b/README.md
@@ -97,18 +97,8 @@ const deleteCount = await users.deleteOne({ _id: insertId });
 const deleteCount2 = await users.deleteMany({ username: "test" });
 
 // Skip
-<<<<<<< HEAD
-const skipTwo = await users.find().skip(2);
-
-// Limit
-const featuredUser = await users.find().limit(5);
-
-// Skip and Limit
-const users = await users.find().skip(5).limit(5);
-=======
 const skipTwo = await users.skip(2).find();
 
 // Limit
 const featuredUser = await users.limit(5).find();
->>>>>>> limit-and-skip
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ const deleteCount = await users.deleteOne({ _id: insertId });
 const deleteCount2 = await users.deleteMany({ username: "test" });
 
 // Skip
+<<<<<<< HEAD
 const skipTwo = await users.find().skip(2);
 
 // Limit
@@ -104,4 +105,10 @@ const featuredUser = await users.find().limit(5);
 
 // Skip and Limit
 const users = await users.find().skip(5).limit(5);
+=======
+const skipTwo = await users.skip(2).find();
+
+// Limit
+const featuredUser = await users.limit(5).find();
+>>>>>>> limit-and-skip
 ```

--- a/README.md
+++ b/README.md
@@ -97,8 +97,11 @@ const deleteCount = await users.deleteOne({ _id: insertId });
 const deleteCount2 = await users.deleteMany({ username: "test" });
 
 // Skip
-const skipTwo = await users.skip(2).find();
+const skipTwo = await users.find().skip(2);
 
 // Limit
-const featuredUser = await users.limit(5).find();
+const featuredUser = await users.find().limit(5);
+
+// Skip and Limit
+const users = await users.find().skip(5).limit(5);
 ```

--- a/ts/collection.ts
+++ b/ts/collection.ts
@@ -150,7 +150,10 @@ export class Collection<T extends any> {
     private readonly client: MongoClient,
     private readonly dbName: string,
     private readonly collectionName: string,
-  ) {}
+  ) { }
+
+  private maxQueryLimit: number = -1;
+  private skipDocCount: number = -1;
 
   private async _find(
     filter?: FilterType<T>,
@@ -200,7 +203,12 @@ export class Collection<T extends any> {
     filter?: FilterType<T>,
     options?: FindOptions,
   ): Promise<Array<T & WithID>> {
-    return parse(await this._find(filter, { findOne: false, ...options }));
+    return parse(await this._find(filter, {
+      findOne: false,
+      limit: this.maxQueryLimit < 0 ? undefined : this.maxQueryLimit,
+      skip: this.skipDocCount < 0 ? undefined : this.skipDocCount,
+      ...options
+    }));
   }
 
   public async insertOne(doc: DocumentType<T>): Promise<ObjectId> {
@@ -376,5 +384,17 @@ export class Collection<T extends any> {
       ),
     );
     return parse(docs) as Array<T & WithID>;
+  }
+
+  // Limit
+  public limit(maxLimit: number) {
+    this.maxQueryLimit = maxLimit;
+    return this;
+  }
+
+  // Skip
+  public skip(skipCount: number) {
+    this.skipDocCount = skipCount;
+    return this;
   }
 }

--- a/ts/collection.ts
+++ b/ts/collection.ts
@@ -156,7 +156,7 @@ export class Collection<T extends any> {
     private readonly client: MongoClient,
     private readonly dbName: string,
     private readonly collectionName: string,
-  ) { }
+  ) {}
 
   private async _find(
     filter?: FilterType<T>,

--- a/ts/collection.ts
+++ b/ts/collection.ts
@@ -150,7 +150,7 @@ export class Collection<T extends any> {
     private readonly client: MongoClient,
     private readonly dbName: string,
     private readonly collectionName: string,
-  ) { }
+  ) {}
 
   private maxQueryLimit: number = -1;
   private skipDocCount: number = -1;
@@ -203,12 +203,14 @@ export class Collection<T extends any> {
     filter?: FilterType<T>,
     options?: FindOptions,
   ): Promise<Array<T & WithID>> {
-    return parse(await this._find(filter, {
-      findOne: false,
-      limit: this.maxQueryLimit < 0 ? undefined : this.maxQueryLimit,
-      skip: this.skipDocCount < 0 ? undefined : this.skipDocCount,
-      ...options
-    }));
+    return parse(
+      await this._find(filter, {
+        findOne: false,
+        limit: this.maxQueryLimit < 0 ? undefined : this.maxQueryLimit,
+        skip: this.skipDocCount < 0 ? undefined : this.skipDocCount,
+        ...options,
+      }),
+    );
   }
 
   public async insertOne(doc: DocumentType<T>): Promise<ObjectId> {

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -37,3 +37,11 @@ export interface UpdateOptions {
   bypassDocumentValidation?: boolean;
   upsert?: boolean;
 }
+export abstract class Cursor {
+  public limit(n: number): this | any {
+    return this;
+  }
+  public skip(n: number): this | any {
+    return this;
+  }
+}


### PR DESCRIPTION
Hay there,
I have added the skip() and limit() feature which I found was missing while I was working on a project with **pagination support**.

```js
// Skip
const skipTwo = await users.skip(2).find();

// Limit
const featuredUser = await users.limit(5).find();
```

Expecting a positive review 👍