### PR TITLE
Fix version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ deno run --allow-net --allow-write --allow-read --allow-plugin --unstable xxx.ts
 ## Examples
 
 ```ts
-import { MongoClient } from "https://deno.land/x/mongo@v0.10.0/mod.ts";
+import { MongoClient } from "https://deno.land/x/mongo@v0.10.1/mod.ts";
 
 const client = new MongoClient();
 client.connectWithUri("mongodb://localhost:27017");


### PR DESCRIPTION
Using the code in the example I get the error, `error: Import 'https://deno.land/x/mongo@v0.10.0/mod.ts' failed: 404 Not Found` 

This PR updates the version to `0.10.1` which fixes this problem